### PR TITLE
feat: add useTextProvider custom hook

### DIFF
--- a/src/TextProviderHOC.jsx
+++ b/src/TextProviderHOC.jsx
@@ -1,24 +1,33 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { TextContext } from './TextProvider';
 
 const withTextProvider = (SomeComponent) => {
-  function TextProviderHOC (props) {
-    const globalText = useContext(TextContext);
+  /* eslint-disable-line no-unused-vars */
+  class TextProviderHOC extends React.Component {
+    constructor(props) {
+      super(props);
+      this.getTextForKey = this.getTextForKey.bind(this);
+    }
 
-    function getTextForKey(key) {
+    getTextForKey(key) {
+      const globalText = this.context;
       if (Object.prototype.hasOwnProperty.call(globalText, key)) {
         return globalText[key];
       }
       return '';
     }
 
-    return (
-      <SomeComponent
-        getTextForKey={getTextForKey}
-        {...props} /* eslint-disable-line react/jsx-props-no-spreading */
-      />
-    );
+    render() {
+      return (
+        <SomeComponent
+          getTextForKey={this.getTextForKey}
+          {...this.props} /* eslint-disable-line react/jsx-props-no-spreading */
+        />
+      );
+    }
   }
+
+  TextProviderHOC.contextType = TextContext;
 
   return TextProviderHOC;
 };

--- a/src/TextProviderHOC.jsx
+++ b/src/TextProviderHOC.jsx
@@ -1,21 +1,19 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { TextContext } from './TextProvider';
 
 const withTextProvider = (SomeComponent) => {
   /* eslint-disable-line no-unused-vars */
   class TextProviderHOC extends React.Component {
-    constructor(props) {
-      super(props);
-      this.getTextForKey = this.getTextForKey.bind(this);
-    }
-
-    getTextForKey(key) {
-      const globalText = this.context;
-      if (Object.prototype.hasOwnProperty.call(globalText, key)) {
-        return globalText[key];
-      }
-      return '';
-    }
+    getTextForKey = id => {
+      const { values, alt } = props;
+      let messageString = Object.prototype.hasOwnProperty.call(this.context, id) ? this.context[id] : alt;
+      // Iterate through all the values given and replace with corresponding key values.
+      Object.keys(values).forEach((key) => {
+        messageString = messageString.replace(`{${key}}`, values[key]);
+      });
+      return messageString;
+    };
 
     render() {
       return (
@@ -28,6 +26,16 @@ const withTextProvider = (SomeComponent) => {
   }
 
   TextProviderHOC.contextType = TextContext;
+
+  TextProviderHOC.propTypes = {
+    values: PropTypes.objectOf(PropTypes.object),
+    alt: PropTypes.string,
+  };
+
+  TextProviderHOC.defaultProps = {
+    values: {},
+    alt: '',
+  };
 
   return TextProviderHOC;
 };

--- a/src/TextProviderHOC.jsx
+++ b/src/TextProviderHOC.jsx
@@ -1,33 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { TextContext } from './TextProvider';
 
 const withTextProvider = (SomeComponent) => {
-  /* eslint-disable-line no-unused-vars */
-  class TextProviderHOC extends React.Component {
-    constructor(props) {
-      super(props);
-      this.getTextForKey = this.getTextForKey.bind(this);
-    }
+  function TextProviderHOC (props) {
+    const globalText = useContext(TextContext);
 
-    getTextForKey(key) {
-      const globalText = this.context;
+    function getTextForKey(key) {
       if (Object.prototype.hasOwnProperty.call(globalText, key)) {
         return globalText[key];
       }
       return '';
     }
 
-    render() {
-      return (
-        <SomeComponent
-          getTextForKey={this.getTextForKey}
-          {...this.props} /* eslint-disable-line react/jsx-props-no-spreading */
-        />
-      );
-    }
+    return (
+      <SomeComponent
+        getTextForKey={getTextForKey}
+        {...props} /* eslint-disable-line react/jsx-props-no-spreading */
+      />
+    );
   }
-
-  TextProviderHOC.contextType = TextContext;
 
   return TextProviderHOC;
 };

--- a/src/TextProviderHook.js
+++ b/src/TextProviderHook.js
@@ -1,6 +1,7 @@
 import { useContext } from 'react';
+import { TextContext } from './TextProvider';
 
-function useTextProvider(context) {
+function useTextProvider(context = TextContext) {
   const globalText = useContext(context);
   return (key) => {
     if (Object.prototype.hasOwnProperty.call(globalText, key)) {

--- a/src/TextProviderHook.js
+++ b/src/TextProviderHook.js
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+
+function useTextProvider(context) {
+  const globalText = useContext(context);
+  return (key) => {
+    if (Object.prototype.hasOwnProperty.call(globalText, key)) {
+      return globalText[key];
+    }
+    return '';
+  };
+}
+
+export { useTextProvider as default };

--- a/src/TextProviderHook.js
+++ b/src/TextProviderHook.js
@@ -5,12 +5,10 @@ function useTextProvider({context = TextContext, values = {}, alt = ''}) {
   const globalText = useContext(context);
   return (id) => {
     let messageString = Object.prototype.hasOwnProperty.call(globalText, id) ? context[id] : alt;
-
     // Iterate through all the values given and replace with corresponding key values.
     Object.keys(values).forEach((key) => {
       messageString = messageString.replace(`{${key}}`, values[key]);
     });
-
     return messageString;
   };
 }

--- a/src/TextProviderHook.js
+++ b/src/TextProviderHook.js
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { TextContext } from './TextProvider';
 
-function useTextProvider({context = TextContext, values = {}, alt = ''}) {
+function useTextProvider(context = TextContext, values = {}, alt = '') {
   const globalText = useContext(context);
   return (id) => {
     let messageString = Object.prototype.hasOwnProperty.call(globalText, id) ? context[id] : alt;

--- a/src/TextProviderHook.js
+++ b/src/TextProviderHook.js
@@ -1,13 +1,17 @@
 import { useContext } from 'react';
 import { TextContext } from './TextProvider';
 
-function useTextProvider(context = TextContext) {
+function useTextProvider({context = TextContext, values = {}, alt = ''}) {
   const globalText = useContext(context);
-  return (key) => {
-    if (Object.prototype.hasOwnProperty.call(globalText, key)) {
-      return globalText[key];
-    }
-    return '';
+  return (id) => {
+    let messageString = Object.prototype.hasOwnProperty.call(globalText, id) ? context[id] : alt;
+
+    // Iterate through all the values given and replace with corresponding key values.
+    Object.keys(values).forEach((key) => {
+      messageString = messageString.replace(`{${key}}`, values[key]);
+    });
+
+    return messageString;
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,6 @@
 import FormattedMessage from './FormattedMessage';
 import TextProvider from './TextProvider';
 import withTextProvider from './TextProviderHOC';
+import useTextProvider from './TextProviderHook';
 
-export {
-  FormattedMessage,
-  TextProvider,
-  withTextProvider,
-};
+export { FormattedMessage, TextProvider, useTextProvider, withTextProvider };

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,6 @@ import TextProvider from './TextProvider';
 import withTextProvider from './TextProviderHOC';
 import useTextProvider from './TextProviderHook';
 
-export { FormattedMessage, TextProvider, useTextProvider, withTextProvider };
+export {
+  FormattedMessage, TextProvider, useTextProvider, withTextProvider,
+};


### PR DESCRIPTION
Fixes issue #80 

Adds new custom hook to be used instead of relying on the HOC to pass the `getTextForKey` prop.

PR checklist:

- [x] Github Issue associated with branch.
- [x] Code passes eslint analysis.
- [x] Code passes cross browser testing.
- [x] Test code coverage is 85% or greater.
- [x] PR branch is up-to-date with latest master branch.
